### PR TITLE
fix segmentation fault

### DIFF
--- a/db.h
+++ b/db.h
@@ -232,7 +232,7 @@ public:
       stats.nTracked = ourId.size();
       stats.nGood = goodId.size();
       stats.nNew = unkId.size();
-      stats.nAge = time(NULL) - idToInfo[ourId[0]].ourLastTry;
+      stats.nAge = ourId.size() > 0 ? time(NULL) - idToInfo[ourId[0]].ourLastTry : 0;
     }
   }
 

--- a/main.cpp
+++ b/main.cpp
@@ -341,6 +341,7 @@ vector<CDnsThread*> dnsThread;
 extern "C" void* ThreadDNS(void* arg) {
   CDnsThread *thread = (CDnsThread*)arg;
   thread->run();
+  return NULL;
 }
 
 int StatCompare(const CAddrReport& a, const CAddrReport& b) {


### PR DESCRIPTION
This PR fixes two issues found:
1. Missed `return` statement (debugging showed that currently g++ with optimization level `-O1` or higher doesn't insert `return` automatically, and execution enters another function with garbage in the stack).
2. Possible access to the element of empty array (`ourId[0]`).